### PR TITLE
feat() : Add some modules and connectors to the stats for CRNA

### DIFF
--- a/src/main/resources/api-allowed-values.json
+++ b/src/main/resources/api-allowed-values.json
@@ -7,13 +7,14 @@
         "Admin","Mediacentre","Wiki","WebConference","CollaborativeEditor","Presences","Stats","Rack",
         "AideAuDevoirs","Alise","artips","Balado","BiblioCollege","Brne","Capytale","CerisePrim","CerisePro","Cesame","Chamilo",
         "CIDJ","CNS","corelycee","DeltaExpert","Educagri","Educ-Arte","Edulib","Edulib2","Edulib-Belin","Edulib-Magnard","EduMalin","EduMaxicours","EduMedia",
-        "edumoov","Elea","Eliot","ElyceeHDF","English-Attack","Esidoc","EulerRessources","EulerRessources-pp","ExplorateurDeMetiers","FoliosOnisep","GRR",
-        "HiSQOOL","HumanRoads","Interforum","InterForum","JuniorUniversalis","KiosqueEDU","KiosqueEDU-aca","KNE-Annabac","KNE-CNS","Kwyk","Labomep","LaboMEP",
-        "LDE","LeLivreScolaire","LeSite-tv","Lstl","madmagz","madmagz-77","madmagz-aisne","madmagz-draaf","madmagz-ent04","madmagz-idf","madmagz-na",
+        "edumoov","Elea","Eliot","ElyceeHDF","English-Attack","Esidoc","EulerRessources","EulerRessources-pp","ExplorateurDeMetiers","FoliosOnisep",
+        "Formulaire","Formulaire-public","Geogebra","GRR",
+        "HiSQOOL","Homework-assistance","HumanRoads","Interforum","InterForum","JuniorUniversalis","KiosqueEDU","KiosqueEDU-aca","KNE-Annabac","KNE-CNS","Kwyk","Labomep","LaboMEP",
+        "LDE","LeLivreScolaire","LeSite-tv","Lool","Lstl","madmagz","madmagz-77","madmagz-aisne","madmagz-draaf","madmagz-ent04","madmagz-idf","madmagz-na",
         "madmagz-nord","madmagz-oise","madmagz-paris","madmagz-regionhdf","madmagz-somme1d","madmagz-somme2d","milliweb-oAuth","MindViewOnline","Moodle","MSEL",
-        "numericours","numeritab","OGIL","OGIL-Region","Onisep","Onisep-Services","Passerelle","PasserellePise","Pearltrees","PMB-lyceeconnecte","ProEPS",
-        "projet-voltaire","Pronote","Sacoche","Salvum","Speakshake","Tactileo","TurboSelf","Universalis","Universalis-Junior",
-        "Webclasseur","Wims-Auto","Wims-Euler","Wims-Math"
+        "numericours","numeritab","OGIL","OGIL-Region","Onisep","Onisep-Services","Passerelle","PasserellePise","Pearltrees","Peertube NA","PMB-lyceeconnecte","ProEPS",
+        "projet-voltaire","Pronote","Riot Region","Sacoche","Salvum","Scratch","Speakshake","Tactileo","TurboSelf","Universalis","Universalis-Junior",
+        "Webclasseur","Wekan Region","Wims-Auto","Wims-Euler","Wims-Math"
     ],
     "devices-mapping" : {
         "select-devices" : ["desktop", "mobile_app", "tablet"],


### PR DESCRIPTION
The CRNA region wants to add some modules and connectors to their stats.
List of the modules added : "Formulaire","Formulaire-public","Geogebra","Homework-assistance","Lool","Scratch"
List of connectors added  : "Peertube NA", "Riot Region", "Wekan Region"