### PR TITLE
WB-2180 fixing non retrieved classes

### DIFF
--- a/src/main/java/fr/wseduc/stats/services/StructureService.java
+++ b/src/main/java/fr/wseduc/stats/services/StructureService.java
@@ -48,7 +48,7 @@ public class StructureService {
                 " WHERE (pg:ProfileGroup OR pg:FunctionGroup) " +
                 " OPTIONAL MATCH (s)-[:HAS_ATTACHMENT]->(ps:Structure)<-[:DEPENDS]-(g)<-[:IN]-(:User {id: {userId}})" +
                 " WHERE (g:ProfileGroup OR g:FunctionGroup) " +
-                " OPTIONAL MATCH (:User {id: {userId}})-[:IN]->(pg:ProfileGroup)-[:DEPENDS]->(c:Class)-[:BELONGS]->(s)" +
+                " OPTIONAL MATCH (:User {id: {userId}})-[:IN]->(:ProfileGroup)-[:DEPENDS]->(c:Class)-[:BELONGS]->(s)" +
                 " WITH s, COLLECT(distinct {id: ps.id, name: ps.name}) as parents, COLLECT(distinct {id: c.id, name: c.name}) as classes" +
                 " WITH DISTINCT s, CASE WHEN any(p in parents where p <> {id: null, name: null}) THEN parents END as parents," +
                 " CASE WHEN any(c in classes where c <> {id: null, name: null}) THEN classes END as classes " +


### PR DESCRIPTION
Ticket lié : https://edifice-community.atlassian.net/browse/WB-2180

Correctif suite à une optimisation de la requête  qui avait mené à la perte de récupération des classes liées à un enseignant.

Difficilement testable en recette, le correctif a été testé manuellement :
- requête neo4j corrigée et jouée sur le serveur neo4j en preprod-hdf et preprod-saas
- classe _StructureService_ corrigée et déployée sur la preprod-hdf : l'accès à l'appli Statistiques est restauré
